### PR TITLE
Remove bound Clone for Actor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-tokio-actor"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 authors = ["fdeantoni <fdeantoni@gmail.com>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-tokio-actor"
-version = "0.3.2"
+version = "0.3.1"
 edition = "2018"
 authors = ["fdeantoni <fdeantoni@gmail.com>"]
 license = "Apache-2.0"

--- a/src/actor/handler.rs
+++ b/src/actor/handler.rs
@@ -81,9 +81,14 @@ impl<E: SystemEvent, A: Actor<E>> ActorMailbox<E, A> {
 
 pub type BoxedMessageHandler<E, A> = Box<dyn MessageHandler<E, A>>;
 
-#[derive(Clone)]
 pub struct HandlerRef<E: SystemEvent, A: Actor<E>> {
     sender: mpsc::UnboundedSender<BoxedMessageHandler<E, A>>,
+}
+
+impl<E: SystemEvent, A: Actor<E>> Clone for HandlerRef<E, A> {
+    fn clone(&self) -> Self {
+        Self { sender: self.sender.clone() }
+    }
 }
 
 impl<E: SystemEvent, A: Actor<E>> HandlerRef<E, A> {

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -133,7 +133,7 @@ pub trait Handler<E: SystemEvent, M: Message>: Send + Sync {
 /// }
 /// ```
 #[async_trait]
-pub trait Actor<E: SystemEvent>: Clone + Send + Sync + 'static {
+pub trait Actor<E: SystemEvent>: Send + Sync + 'static {
     /// Defines the supervision strategy to use for this actor. By default it is
     /// `Stop` which simply stops the actor if an error occurs at startup. You
     /// can also set this to [`SupervisionStrategy::Retry`] with a chosen
@@ -165,10 +165,15 @@ pub trait Actor<E: SystemEvent>: Clone + Send + Sync + 'static {
 
 /// A clonable actor reference. It basically holds a Sender that can send messages
 /// to the mailbox (receiver) of the actor.
-#[derive(Clone)]
 pub struct ActorRef<E: SystemEvent, A: Actor<E>> {
     path: ActorPath,
     sender: handler::HandlerRef<E, A>,
+}
+
+impl<E: SystemEvent, A: Actor<E>> Clone for ActorRef<E, A> {
+    fn clone(&self) -> Self {
+        Self { path: self.path.clone(), sender: self.sender.clone() }
+    }
 }
 
 impl<E: SystemEvent, A: Actor<E>> ActorRef<E, A> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@
 //! // Mark the struct as a system event message.
 //! impl SystemEvent for TestEvent {}
 //!
-//! // The actor struct must derive Clone.
-//! #[derive(Default, Clone)]
+//! // The actor struct must be Send + Sync but need not be Clone
+//! #[derive(Default)]
 //! struct TestActor {
 //!     counter: usize
 //! }

--- a/src/system.rs
+++ b/src/system.rs
@@ -162,7 +162,7 @@ mod tests {
 
     impl SystemEvent for TestEvent {}
 
-    #[derive(Default, Clone)]
+    #[derive(Default)]
     struct TestActor {
         counter: usize,
     }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -8,8 +8,7 @@ struct TestEvent(String);
 // Mark the struct as a system event message.
 impl SystemEvent for TestEvent {}
 
-// The actor struct must derive Clone.
-#[derive(Clone)]
+// Define the actor
 struct TestActor {
     counter: usize,
 }

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -7,7 +7,6 @@ struct TestEvent(String);
 impl SystemEvent for TestEvent {}
 
 // Define the actor
-#[derive(Clone)]
 struct TestActor {
     counter: usize,
 }

--- a/tests/pingpong.rs
+++ b/tests/pingpong.rs
@@ -5,14 +5,12 @@ struct EventMessage(String);
 
 impl SystemEvent for EventMessage {}
 
-#[derive(Clone)]
 struct PingActor {
     counter: i8,
 }
 
 impl Actor<EventMessage> for PingActor {}
 
-#[derive(Clone)]
 struct PongActor;
 
 impl Actor<EventMessage> for PongActor {}


### PR DESCRIPTION
Actor only had to be Clone so that ActorRef/HandlerRef could derive Clone, as Actor was a bound on their generic type parameters. Trivial implementations of clone for ActorRef/HandlerRef remove that requirement allowing a wider range of types to be used as Actors.

I made this change because I wanted to use a struct that couldn't be cloned as an Actor in this framework. All the tests pass and I've updated them to not derive clone for the actor structs, mostly.