### PR TITLE
Ask and tell take &self instead of &mut self

### DIFF
--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -77,7 +77,7 @@ async fn start_echo(
         .unwrap_or_else(|| Uuid::new_v4().to_string());
     let actor_name = format!("echo-actor-{}", &addr);
     // Launch the actor on our actor system
-    let mut actor_ref = system.create_actor(&actor_name, actor).await.unwrap();
+    let actor_ref = system.create_actor(&actor_name, actor).await.unwrap();
 
     // Loop over all websocket messages received over ws_in
     while let Some(result) = ws_in.next().await {

--- a/src/actor/handler.rs
+++ b/src/actor/handler.rs
@@ -91,7 +91,7 @@ impl<E: SystemEvent, A: Actor<E>> HandlerRef<E, A> {
         HandlerRef { sender }
     }
 
-    pub fn tell<M>(&mut self, msg: M) -> Result<(), ActorError>
+    pub fn tell<M>(&self, msg: M) -> Result<(), ActorError>
     where
         M: Message,
         A: Handler<E, M>,
@@ -105,7 +105,7 @@ impl<E: SystemEvent, A: Actor<E>> HandlerRef<E, A> {
         }
     }
 
-    pub async fn ask<M>(&mut self, msg: M) -> Result<M::Response, ActorError>
+    pub async fn ask<M>(&self, msg: M) -> Result<M::Response, ActorError>
     where
         M: Message,
         A: Handler<E, M>,
@@ -173,7 +173,7 @@ mod tests {
             MailboxSender<MyMessage, MyActor>,
             MailboxReceiver<MyMessage, MyActor>,
         ) = ActorMailbox::create();
-        let mut actor_ref = HandlerRef { sender };
+        let actor_ref = HandlerRef { sender };
         let bus = EventBus::<MyMessage>::new(1000);
         let system = ActorSystem::new("test", bus);
         let path = ActorPath::from("/test");
@@ -202,7 +202,7 @@ mod tests {
             MailboxSender<MyMessage, MyActor>,
             MailboxReceiver<MyMessage, MyActor>,
         ) = ActorMailbox::create();
-        let mut actor_ref = HandlerRef { sender };
+        let actor_ref = HandlerRef { sender };
         let bus = EventBus::<MyMessage>::new(1000);
         let system = ActorSystem::new("test", bus);
         let path = ActorPath::from("/test");

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -184,7 +184,7 @@ impl<E: SystemEvent, A: Actor<E>> ActorRef<E, A> {
     }
 
     /// Fire and forget sending of messages to this actor.
-    pub fn tell<M>(&mut self, msg: M) -> Result<(), ActorError>
+    pub fn tell<M>(&self, msg: M) -> Result<(), ActorError>
     where
         M: Message,
         A: Handler<E, M>,
@@ -193,7 +193,7 @@ impl<E: SystemEvent, A: Actor<E>> ActorRef<E, A> {
     }
 
     /// Send a message to an actor, expecting a response.
-    pub async fn ask<M>(&mut self, msg: M) -> Result<M::Response, ActorError>
+    pub async fn ask<M>(&self, msg: M) -> Result<M::Response, ActorError>
     where
         M: Message,
         A: Handler<E, M>,

--- a/src/system.rs
+++ b/src/system.rs
@@ -257,7 +257,7 @@ mod tests {
 
         let bus = EventBus::<TestEvent>::new(1000);
         let system = ActorSystem::new("test", bus);
-        let mut actor_ref = system.create_actor("test-actor", actor).await.unwrap();
+        let actor_ref = system.create_actor("test-actor", actor).await.unwrap();
         let result = actor_ref.ask(msg).await.unwrap();
 
         assert_eq!(result, 1);
@@ -286,7 +286,7 @@ mod tests {
 
         let initial_message = "hello world!".to_string();
         let actor_fn = || create_other(initial_message);
-        let mut actor_ref = system
+        let actor_ref = system
             .get_or_create_actor("test-actor", actor_fn)
             .await
             .unwrap();
@@ -311,7 +311,7 @@ mod tests {
         let system = ActorSystem::new("test", bus);
 
         {
-            let mut actor_ref = system.create_actor("test-actor", actor).await.unwrap();
+            let actor_ref = system.create_actor("test-actor", actor).await.unwrap();
             let result = actor_ref.ask(msg).await.unwrap();
 
             assert_eq!(result, 1);
@@ -334,7 +334,7 @@ mod tests {
 
         let bus = EventBus::<TestEvent>::new(1000);
         let system = ActorSystem::new("test", bus);
-        let mut actor_ref = system.create_actor("test-actor", actor).await.unwrap();
+        let actor_ref = system.create_actor("test-actor", actor).await.unwrap();
 
         let mut events = system.events();
         tokio::spawn(async move {
@@ -366,7 +366,7 @@ mod tests {
         let system = ActorSystem::new("test", bus);
         let original = system.create_actor("test-actor", actor).await.unwrap();
 
-        if let Some(mut actor_ref) = system.get_actor::<TestActor>(original.path()).await {
+        if let Some(actor_ref) = system.get_actor::<TestActor>(original.path()).await {
             let msg = TestMessage(10);
             let result = actor_ref.ask(msg).await.unwrap();
             assert_eq!(result, 1);
@@ -374,7 +374,7 @@ mod tests {
             panic!("It should have retrieved the actor!")
         }
 
-        if let Some(mut actor_ref) = system.get_actor::<OtherActor>(original.path()).await {
+        if let Some(actor_ref) = system.get_actor::<OtherActor>(original.path()).await {
             let msg = OtherMessage("Hello world!".to_string());
             let result = actor_ref.ask(msg).await.unwrap();
             println!("Result is: {}", result);
@@ -400,7 +400,7 @@ mod tests {
         let system = ActorSystem::new("test", bus);
 
         {
-            let mut actor_ref = system.create_actor("test-actor", actor).await.unwrap();
+            let actor_ref = system.create_actor("test-actor", actor).await.unwrap();
             let msg = OtherMessage("new message!".to_string());
             let result = actor_ref.ask(msg).await.unwrap();
             assert_eq!(result, "new message!".to_string());

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -65,7 +65,7 @@ async fn simple_message() {
     // Create the actor system with the event bus
     let system = ActorSystem::new("test", bus);
     // Launch the actor on the actor system
-    let mut actor_ref = system.create_actor("test-actor", actor).await.unwrap();
+    let actor_ref = system.create_actor("test-actor", actor).await.unwrap();
 
     // Listen for events on the system event bus
     let mut events: EventReceiver<TestEvent> = system.events();

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -79,7 +79,7 @@ async fn multi_message() {
 
     let bus = EventBus::<TestEvent>::new(1000);
     let system = ActorSystem::new("test", bus);
-    let mut actor_ref = system.create_actor("test-actor", actor).await.unwrap();
+    let actor_ref = system.create_actor("test-actor", actor).await.unwrap();
 
     let mut events = system.events();
     tokio::spawn(async move {

--- a/tests/pingpong.rs
+++ b/tests/pingpong.rs
@@ -49,7 +49,7 @@ impl Handler<EventMessage, PingMessage> for PingActor {
     ) -> PongMessage {
         if let PingMessage::Start(message) = msg {
             let limit = message.limit;
-            if let Some(mut destination) = ctx
+            if let Some(destination) = ctx
                 .system
                 .get_actor::<PongActor>(&message.destination)
                 .await
@@ -94,7 +94,7 @@ async fn test_ping_pong() {
     let system = ActorSystem::new("test", bus);
 
     let ping = PingActor { counter: 0 };
-    let mut ping_ref = system.create_actor("ping", ping).await.unwrap();
+    let ping_ref = system.create_actor("ping", ping).await.unwrap();
     let pong = PongActor {};
     let pong_ref = system.create_actor("pong", pong).await.unwrap();
 


### PR DESCRIPTION
ActorRef::ask and ActorRef::tell did not need to take &mut self. This constraint was an issue for my use case so I got rid of it. This should not be a breaking change.